### PR TITLE
SVG background, coords refactor & text changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
     <title>Graphit</title>
   </head>
   <body>
-    <span>Draw a line and see the equation</span>
+    <h1>Draw a line and see the equation</h1>
     <canvas></canvas>
+    <output name="equation"></output>
   </body>
 </html>

--- a/src/images/background-graph.svg
+++ b/src/images/background-graph.svg
@@ -1,46 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="1000px" height="1001px" viewBox="0 0 1000 1001" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
-    <title>background</title>
-    <desc>Created with Sketch.</desc>
-    <g id="background" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(0.000000, 1.000000)">
-        <g id="Group" transform="translate(50.000000, 100.000000)">
-            <path id="Line-2" d="M28.5,397.5 L871.5,397.5 L871.5,385.5 L900.5,400 L871.5,414.5 L871.5,402.5 L28.5,402.5 L28.5,414.5 L-0.5,400 L28.5,385.5 L28.5,397.5 Z" fill="#FF5CC6" fill-rule="nonzero"></path>
-            <path d="M50,450 L850,450" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,500 L850,500" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,550 L850,550" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,600 L850,600" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,650 L850,650" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,700 L850,700" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,750 L850,750" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,800 L850,800" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,0.5 L850,0.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,50.5 L850,50.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,100.5 L850,100.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,150.5 L850,150.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,200.5 L850,200.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,250.5 L850,250.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,300.5 L850,300.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,350.5 L850,350.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-        </g>
-        <g id="Group" transform="translate(500.000000, 500.500000) rotate(90.000000) translate(-500.000000, -500.500000) translate(50.000000, 100.000000)">
-            <path id="Line-2" d="M28.5,397.5 L871.5,397.5 L871.5,385.5 L900.5,400 L871.5,414.5 L871.5,402.5 L28.5,402.5 L28.5,414.5 L-0.5,400 L28.5,385.5 L28.5,397.5 Z" fill="#FF5CC6" fill-rule="nonzero"></path>
-            <path d="M50,450 L850,450" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,500 L850,500" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,550 L850,550" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,600 L850,600" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,650 L850,650" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,700 L850,700" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,750 L850,750" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,800 L850,800" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,0.5 L850,0.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,50.5 L850,50.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,100.5 L850,100.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,150.5 L850,150.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,200.5 L850,200.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,250.5 L850,250.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,300.5 L850,300.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-            <path d="M50,350.5 L850,350.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
-        </g>
-    </g>
+<svg width="1000" height="1001" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#FF5CC6" fill-rule="nonzero" d="M78.5 498.5h843v-12l29 14.5-29 14.5v-12h-843v12l-29-14.5 29-14.5v12z"/>
+    <path stroke="#FF5CC6" stroke-width="3" stroke-linecap="square" d="M100 551h800M100 601h800M100 651h800M100 701h800M100 751h800M100 801h800M100 851h800M100 901h800M100 101.5h800M100 151.5h800M100 201.5h800M100 251.5h800M100 301.5h800M100 351.5h800M100 401.5h800M100 451.5h800" />
+    <path fill="#FF5CC6" fill-rule="nonzero" d="M503 80v843h12l-14.5 29-14.5-29h12V80h-12l14.5-29L515 80h-12z"/>
+    <path stroke="#FF5CC6" stroke-width="3" stroke-linecap="square" d="M450.5 101.5v800M400.5 101.5v800M350.5 101.5v800M300.5 101.5v800M250.5 101.5v800M200.5 101.5v800M150.5 101.5v800M100.5 101.5v800M900 101.5v800M850 101.5v800M800 101.5v800M750 101.5v800M700 101.5v800M650 101.5v800M600 101.5v800M550 101.5v800" />
+  </g>
 </svg>

--- a/src/images/background-graph.svg
+++ b/src/images/background-graph.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1000px" height="1001px" viewBox="0 0 1000 1001" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>background</title>
+    <desc>Created with Sketch.</desc>
+    <g id="background" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(0.000000, 1.000000)">
+        <g id="Group" transform="translate(50.000000, 100.000000)">
+            <path id="Line-2" d="M28.5,397.5 L871.5,397.5 L871.5,385.5 L900.5,400 L871.5,414.5 L871.5,402.5 L28.5,402.5 L28.5,414.5 L-0.5,400 L28.5,385.5 L28.5,397.5 Z" fill="#FF5CC6" fill-rule="nonzero"></path>
+            <path d="M50,450 L850,450" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,500 L850,500" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,550 L850,550" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,600 L850,600" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,650 L850,650" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,700 L850,700" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,750 L850,750" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,800 L850,800" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,0.5 L850,0.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,50.5 L850,50.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,100.5 L850,100.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,150.5 L850,150.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,200.5 L850,200.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,250.5 L850,250.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,300.5 L850,300.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,350.5 L850,350.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+        </g>
+        <g id="Group" transform="translate(500.000000, 500.500000) rotate(90.000000) translate(-500.000000, -500.500000) translate(50.000000, 100.000000)">
+            <path id="Line-2" d="M28.5,397.5 L871.5,397.5 L871.5,385.5 L900.5,400 L871.5,414.5 L871.5,402.5 L28.5,402.5 L28.5,414.5 L-0.5,400 L28.5,385.5 L28.5,397.5 Z" fill="#FF5CC6" fill-rule="nonzero"></path>
+            <path d="M50,450 L850,450" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,500 L850,500" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,550 L850,550" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,600 L850,600" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,650 L850,650" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,700 L850,700" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,750 L850,750" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,800 L850,800" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,0.5 L850,0.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,50.5 L850,50.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,100.5 L850,100.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,150.5 L850,150.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,200.5 L850,200.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,250.5 L850,250.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,300.5 L850,300.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+            <path d="M50,350.5 L850,350.5" id="Line-2" stroke="#FF5CC6" stroke-width="3" stroke-linecap="square"></path>
+        </g>
+    </g>
+</svg>

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function resize() {
   // size the canvas to be a square that
   // will fit in the middle of the page
   const {innerWidth, innerHeight} = window
-  const size = Math.min(innerWidth, innerHeight) * 0.8
+  const size = Math.min(innerWidth, innerHeight) * 0.8 // 0.8 = 10% padding
   const top = ((innerHeight - size) / 2)
   const left = ((innerWidth - size) / 2)
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function resize() {
   context.resetTransform()
   context.translate(canvas.width/2, canvas.height/2);
   const scale = canvas.width / 20 /* 20 units on width of page */
-  context.scale(scale,scale);
+  context.scale(scale, -scale);
   context.lineWidth = 0.25
   context.lineCap = 'round'
 }
@@ -59,12 +59,12 @@ function getCoordinates(event) {
   if (['mousedown', 'mousemove'].includes(event.type)) {
     return [
       (((event.pageX - bounds.left) / bounds.width) - .5) * 20,
-      (((event.pageY - bounds.top) / bounds.height) - .5) * 20,
+      -(((event.pageY - bounds.top) / bounds.height) - .5) * 20,
     ];
   } else {
     return [
       (((event.touches[0].pageX - bounds.left) / bounds.width) - .5) * 20,
-      (((event.touches[0].pageY - bounds.top) / bounds.height) - .5) * 20,
+      -(((event.touches[0].pageY - bounds.top) / bounds.height) - .5) * 20,
     ];
   }
 }
@@ -118,7 +118,7 @@ function exit() {
   const slope = getSlope(origX, origY, finalX, finalY);
 
   // put the equation together
-  const yPoint = (origY + (slope * origX)) * -1;
+  const yPoint = (origY + (slope * origX));
 
   // draw out the linear line from equation
   snapToLinear();

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -17,9 +17,9 @@ span {
 }
 
 canvas {
-  background-image: url('background-graph.jpg');
+  background-image: url('../images/background-graph.svg');
   background-repeat: no-repeat;
-  background-size: cover;
+  background-size: contain;
   background-position: 50% 50%;
   letter-spacing: .2rem;
   -webkit-text-size-adjust: 100%;

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,19 +1,29 @@
 html,
 body,
 canvas {
-  height: 100%;
-  width: 100%;
   margin: 0;
   user-select: none;
   overflow: hidden;
+  font-family: Arial, Helvetica, sans-serif
 }
 
-span {
+h1 {
   position: absolute;
   user-select: none;
   font-size: 1.5rem;
   text-align: center;
   width: 100%;
+  z-index: 1;
+  font-weight: 400
+}
+
+output {
+  position: absolute;
+  font-size: 1.5rem;
+  text-align: center;
+  width: 100%;
+  bottom: .5rem;
+  z-index: 1;
 }
 
 canvas {


### PR DESCRIPTION
I wanted to add a new background, because the original one was a bit blurry, and I couldn't see the black lines against it.

![image](https://user-images.githubusercontent.com/51385/62014294-0135ec80-b197-11e9-887e-8b09944af1c0.png)

… though, this turned out to be a bit of a rabbit hole!  I kept on breaking more things as I tried to fix them, and so ended up with:

* There's a resize function that will always make the canvas square and centred in the page
* Using Pixel Device Ratio - means that the lines will be sharp on retina/phone displays
* The Equation text is now in an html element
* The canvas context is transformed, so draws happen in the "actual" units

This last one is kinda weird.  Now when you do something like this:

```js
context.beginPath()
context.moveTo(0,0)
context.lineTo(5,5)
context.lineTo(5,0)
context.fill()
```

It automatically maps them to match the graph coordinate system.  So you get something like this:

![image](https://user-images.githubusercontent.com/51385/62014419-bcab5080-b198-11e9-819d-5065d75d3ce8.png)

It's kind of awkward for the mouse/touch events, and line-widths.  Though it makes the logic for calculating the line equation a lot more straightforward, and hopefully it'll make it easier if you wanted to extend it to other things!